### PR TITLE
Fix patient access crash

### DIFF
--- a/Main.fs
+++ b/Main.fs
@@ -15,10 +15,10 @@ do ()
 type Script() =
     member __.Execute(context: ScriptContext) =
 
-        context.Patient.BeginModifications()
-
         result {
             let! patient = getCurrentPatient context
+
+            patient.BeginModifications()
 
             let! course = getCurrentCourse context
 


### PR DESCRIPTION
only call `BeginModifications` after confirming patient exists